### PR TITLE
【スクリプト実装・修正】敵の陣地や橋にユニットを置けなくしました

### DIFF
--- a/Infection/Assets/Scenes/Test_Katayama.unity
+++ b/Infection/Assets/Scenes/Test_Katayama.unity
@@ -482,7 +482,9 @@ GameObject:
   m_Component:
   - component: {fileID: 339295245}
   - component: {fileID: 339295246}
-  m_Layer: 0
+  - component: {fileID: 339295248}
+  - component: {fileID: 339295247}
+  m_Layer: 4
   m_Name: Ally_Castle
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -559,6 +561,64 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &339295247
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 339295244}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 955eb309803f53b4bac9b09cf9e71e1c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!61 &339295248
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 339295244}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 2}
+  m_EdgeRadius: 0
 --- !u!1 &453064838
 GameObject:
   m_ObjectHideFlags: 0
@@ -1025,6 +1085,153 @@ MonoBehaviour:
   areaMin: {x: -1, y: -3}
   areaMax: {x: -8, y: 5}
   padding: {x: 0, y: 0}
+--- !u!1 &686272692
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 686272694}
+  - component: {fileID: 686272693}
+  - component: {fileID: 686272696}
+  - component: {fileID: 686272695}
+  m_Layer: 6
+  m_Name: Prohibited_Areas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &686272693
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 686272692}
+  m_Enabled: 0
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &686272694
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 686272692}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5, y: 1, z: 0}
+  m_LocalScale: {x: 12, y: 9, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &686272695
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 686272692}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 955eb309803f53b4bac9b09cf9e71e1c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!61 &686272696
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 686272692}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &702633728
 GameObject:
   m_ObjectHideFlags: 0
@@ -1458,7 +1665,9 @@ GameObject:
   m_Component:
   - component: {fileID: 909830715}
   - component: {fileID: 909830716}
-  m_Layer: 0
+  - component: {fileID: 909830718}
+  - component: {fileID: 909830717}
+  m_Layer: 4
   m_Name: Ally_Ramparts
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1535,6 +1744,64 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &909830717
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 909830714}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 955eb309803f53b4bac9b09cf9e71e1c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!61 &909830718
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 909830714}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &935416481
 GameObject:
   m_ObjectHideFlags: 0
@@ -2460,8 +2727,8 @@ Transform:
   m_GameObject: {fileID: 1637495185}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.0006, z: 0}
-  m_LocalScale: {x: 2, y: 7.9991984, z: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalScale: {x: 2, y: 8, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1901986969}
@@ -2989,10 +3256,10 @@ Transform:
   - {fileID: 1637495186}
   - {fileID: 1008644931}
   - {fileID: 33009032}
-  - {fileID: 1618866313}
   - {fileID: 339295245}
-  - {fileID: 935416482}
+  - {fileID: 1618866313}
   - {fileID: 909830715}
+  - {fileID: 935416482}
   - {fileID: 1820526190}
   - {fileID: 54793207}
   m_Father: {fileID: 0}
@@ -3171,7 +3438,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   unitPrefab: {fileID: 3965370889875825912, guid: a36d95eeb3d14eb46aa0f59385bd7f24, type: 3}
-  dragIconPrefab: {fileID: 495446340}
+  blockAreaLayer:
+    serializedVersion: 2
+    m_Bits: 64
 --- !u!114 &2095173943
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3263,3 +3532,4 @@ SceneRoots:
   - {fileID: 293596344}
   - {fileID: 1655355620}
   - {fileID: 731969208}
+  - {fileID: 686272694}

--- a/Infection/Assets/Scripts/MouseBlockArea.cs
+++ b/Infection/Assets/Scripts/MouseBlockArea.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+/// マウスが進入できないブロックエリア
+[RequireComponent(typeof(BoxCollider2D))]
+public class MouseBlockArea : MonoBehaviour
+{
+    private void Reset()
+    {
+        // 自動的にトリガーON
+        GetComponent<Collider2D>().isTrigger = true;
+    }
+
+    private void OnDrawGizmos()
+    {
+        // シーン上で分かりやすく表示
+        Gizmos.color = new Color(1f, 0f, 0f, 0.3f);
+        if (TryGetComponent(out Collider2D col))
+        {
+            Gizmos.DrawCube(col.bounds.center, col.bounds.size);
+        }
+    }
+}

--- a/Infection/Assets/Scripts/MouseBlockArea.cs.meta
+++ b/Infection/Assets/Scripts/MouseBlockArea.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 955eb309803f53b4bac9b09cf9e71e1c

--- a/Infection/Assets/Scripts/UnitDragHandler.cs
+++ b/Infection/Assets/Scripts/UnitDragHandler.cs
@@ -16,13 +16,18 @@ public class UnitDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
     [Header("配置するユニットプレハブ")]
     public GameObject unitPrefab;
 
+    [Header("禁止エリアのLayer")]
+    [SerializeField] private LayerMask blockAreaLayer;
+
     private GameObject dragPreviewObject;
     private Camera cam;
 
-    // スナップする距離のしきい値
     private const float SNAP_THRESHOLD = 1.0f;
 
     public static TaskCompletionSource<PointerEventData> dragEndTcs;
+
+    // 最後に合法だった位置を記録
+    private Vector3? lastValidPosition = null;
 
     private void Start()
     {
@@ -33,11 +38,13 @@ public class UnitDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
     {
         dragEndTcs = new TaskCompletionSource<PointerEventData>();
 
-        // 仮の表示用ユニットを生成（半透明）
+
         dragPreviewObject = Instantiate(unitPrefab);
         SetDragPreviewAlpha(dragPreviewObject, 0.5f);
+        lastValidPosition = null;
 
         _ = WaitEndDrag.WaitDragEndAsync();
+
     }
 
     public void OnDrag(PointerEventData eventData)
@@ -47,7 +54,27 @@ public class UnitDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
         Vector3 worldPos = cam.ScreenToWorldPoint(Input.mousePosition);
         worldPos.z = 0f;
 
-        // 最も近い DropField を探す
+        // 禁止エリアにマウスがあるとき
+        if (IsPointerOverBlockedArea(worldPos))
+        {
+            if (lastValidPosition.HasValue)
+            {
+                // 最後の合法マスに表示
+                dragPreviewObject.SetActive(true);
+                dragPreviewObject.transform.position = lastValidPosition.Value;
+            }
+            else
+            {
+                // 合法マスがまだ見つかってない → 非表示
+                dragPreviewObject.SetActive(false);
+            }
+
+            return;
+        }
+
+        // 合法な位置 → 仮ユニットをスナップまたは追従
+        dragPreviewObject.SetActive(true);
+
         GameObject[] dropFields = GameObject.FindGameObjectsWithTag("DropField");
 
         float minDist = float.MaxValue;
@@ -63,14 +90,15 @@ public class UnitDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
             }
         }
 
-        // 一定距離内ならスナップ、それ以外は通常追従
         if (nearest != null && minDist <= SNAP_THRESHOLD)
         {
             dragPreviewObject.transform.position = nearest.position;
+            lastValidPosition = nearest.position;
         }
         else
         {
             dragPreviewObject.transform.position = worldPos;
+            lastValidPosition = null; // 無効にしておく
         }
     }
 
@@ -78,24 +106,43 @@ public class UnitDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
     {
         if (dragPreviewObject != null)
         {
-            Destroy(dragPreviewObject); // 仮オブジェクト削除
+            Destroy(dragPreviewObject);
         }
 
         Vector3 worldPos = cam.ScreenToWorldPoint(Input.mousePosition);
         worldPos.z = 0f;
 
+        if (IsPointerOverBlockedArea(worldPos))
+        {
+            // 禁止エリア上：保存された有効位置に配置する
+            if (lastValidPosition.HasValue)
+            {
+                Instantiate(unitPrefab, lastValidPosition.Value, Quaternion.identity);
+            }
+            return;
+        }
+
         RaycastHit2D hit = Physics2D.Raycast(worldPos, Vector2.zero);
         if (hit.collider != null && hit.collider.CompareTag("DropField"))
         {
-            // 本物のユニットをマスに生成
             UnitFormation u = GameObject.Find("UnitFormation").GetComponent<UnitFormation>();
             u.UnitGenerate(gameObject, hit.collider.transform.position);
         }
+        else if (lastValidPosition.HasValue)
+        {
+            // 範囲外だけど直前まで有効位置にいた
+            Instantiate(unitPrefab, lastValidPosition.Value, Quaternion.identity);
+        }
 
         dragEndTcs?.TrySetResult(eventData);
+
     }
 
-    // 半透明表示にする（仮オブジェクト用）
+    private bool IsPointerOverBlockedArea(Vector3 worldPos)
+    {
+        return Physics2D.OverlapPoint(worldPos, blockAreaLayer) != null;
+    }
+
     private void SetDragPreviewAlpha(GameObject obj, float alpha)
     {
         foreach (var sr in obj.GetComponentsInChildren<SpriteRenderer>())
@@ -105,6 +152,4 @@ public class UnitDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
             sr.color = c;
         }
     }
-
-
 }

--- a/Infection/ProjectSettings/TagManager.asset
+++ b/Infection/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 3
   tags:
   - DropField
+  - Tile
   layers:
   - Default
   - TransparentFX
@@ -12,7 +13,7 @@ TagManager:
   - 
   - Water
   - UI
-  - 
+  - Prohibited_Areas
   - 
   - 
   - 


### PR DESCRIPTION
ユニットの配置禁止範囲のスクリプトMouseBlockAreaを作成しました。
配置禁止範囲にユニットを置けないようにUnitDragHandlerスクリプトを修正しました。