### PR TITLE
【スクリプト】　『担当：竹下歩』　ユニットの移動ロジック作成

### DIFF
--- a/Infection/Assets/Prefabs/Grid.prefab
+++ b/Infection/Assets/Prefabs/Grid.prefab
@@ -118,7 +118,7 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0

--- a/Infection/Assets/Scenes/Test_Ayumu.unity
+++ b/Infection/Assets/Scenes/Test_Ayumu.unity
@@ -703,7 +703,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0.00027560658}
+  m_AnchoredPosition: {x: 0, y: -0.00013166749}
   m_SizeDelta: {x: 0, y: 300}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &126996983
@@ -1192,93 +1192,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 254396283}
   m_CullTransparentMesh: 1
---- !u!1 &326033491
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 326033493}
-  - component: {fileID: 326033492}
-  m_Layer: 0
-  m_Name: EnemySpawnPoint
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!212 &326033492
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 326033491}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
-  m_Color: {r: 1, g: 0.740566, b: 0.740566, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &326033493
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 326033491}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -6.87, y: 1.29, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &332839783
 GameObject:
   m_ObjectHideFlags: 0
@@ -2027,6 +1940,10 @@ GameObject:
   m_Component:
   - component: {fileID: 428569241}
   - component: {fileID: 428569242}
+  - component: {fileID: 428569244}
+  - component: {fileID: 428569243}
+  - component: {fileID: 428569246}
+  - component: {fileID: 428569245}
   m_Layer: 0
   m_Name: River
   m_TagString: Untagged
@@ -2104,6 +2021,171 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!50 &428569243
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 428569240}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 7
+--- !u!61 &428569244
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 428569240}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0.44578758}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 0.10842484}
+  m_EdgeRadius: 0
+--- !u!61 &428569245
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 428569240}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0.011314303}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 0.4733714}
+  m_EdgeRadius: 0
+--- !u!61 &428569246
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 428569240}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: -0.4395107}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 0.12097865}
+  m_EdgeRadius: 0
 --- !u!1 &502327156
 GameObject:
   m_ObjectHideFlags: 0
@@ -3270,6 +3352,93 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 627136875}
   m_CullTransparentMesh: 1
+--- !u!1 &656992626
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 656992627}
+  - component: {fileID: 656992628}
+  m_Layer: 0
+  m_Name: BridgePoint_Down_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &656992627
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 656992626}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.52, y: -1.47, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1699896757}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &656992628
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 656992626}
+  m_Enabled: 0
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &694092610
 GameObject:
   m_ObjectHideFlags: 0
@@ -3322,6 +3491,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   unitPrefab: {fileID: 7387470101939567078, guid: 2fd52b6a9bf887b47b8b0d6f08941b18, type: 3}
+  blockAreaLayer:
+    serializedVersion: 2
+    m_Bits: 0
 --- !u!114 &694092613
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3591,6 +3763,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   unitPrefab: {fileID: 7387470101939567078, guid: 2fd52b6a9bf887b47b8b0d6f08941b18, type: 3}
+  blockAreaLayer:
+    serializedVersion: 2
+    m_Bits: 0
 --- !u!114 &737045799
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4346,8 +4521,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 414390089}
   m_HandleRect: {fileID: 414390088}
   m_Direction: 2
-  m_Value: 0
-  m_Size: 0.98457
+  m_Value: 1
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -4665,6 +4840,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   unitPrefab: {fileID: 7387470101939567078, guid: 2fd52b6a9bf887b47b8b0d6f08941b18, type: 3}
+  blockAreaLayer:
+    serializedVersion: 2
+    m_Bits: 0
 --- !u!114 &903850979
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5082,6 +5260,142 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 960009447}
   m_CullTransparentMesh: 1
+--- !u!1 &975575536
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 975575537}
+  - component: {fileID: 975575539}
+  - component: {fileID: 975575538}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &975575537
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 975575536}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1880727418}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &975575538
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 975575536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Hide
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 70
+  m_fontSizeBase: 70
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &975575539
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 975575536}
+  m_CullTransparentMesh: 1
 --- !u!1 &978962668
 GameObject:
   m_ObjectHideFlags: 0
@@ -5134,6 +5448,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   unitPrefab: {fileID: 7387470101939567078, guid: 2fd52b6a9bf887b47b8b0d6f08941b18, type: 3}
+  blockAreaLayer:
+    serializedVersion: 2
+    m_Bits: 0
 --- !u!114 &978962671
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5291,6 +5608,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   unitPrefab: {fileID: 7387470101939567078, guid: 2fd52b6a9bf887b47b8b0d6f08941b18, type: 3}
+  blockAreaLayer:
+    serializedVersion: 2
+    m_Bits: 0
 --- !u!114 &1018204962
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6133,6 +6453,93 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1220403879}
   m_CullTransparentMesh: 1
+--- !u!1 &1241678191
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1241678192}
+  - component: {fileID: 1241678193}
+  m_Layer: 0
+  m_Name: BridgePoint_Down_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1241678192
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1241678191}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.52, y: -1.47, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1699896757}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1241678193
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1241678191}
+  m_Enabled: 0
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &1254957207
 GameObject:
   m_ObjectHideFlags: 0
@@ -6237,6 +6644,93 @@ MonoBehaviour:
   areaMin: {x: 1, y: -3}
   areaMax: {x: 8, y: 5}
   padding: {x: 0, y: 0}
+--- !u!1 &1271740833
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1271740834}
+  - component: {fileID: 1271740835}
+  m_Layer: 0
+  m_Name: BridgePoint_Up_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1271740834
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1271740833}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.52, y: 3.51, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1699896757}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1271740835
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1271740833}
+  m_Enabled: 0
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &1319628665
 GameObject:
   m_ObjectHideFlags: 0
@@ -6941,6 +7435,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   unitPrefab: {fileID: 7387470101939567078, guid: 2fd52b6a9bf887b47b8b0d6f08941b18, type: 3}
+  blockAreaLayer:
+    serializedVersion: 2
+    m_Bits: 0
 --- !u!114 &1483928341
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7462,6 +7959,7 @@ RectTransform:
   - {fileID: 626193148}
   - {fileID: 1592632257}
   - {fileID: 916851796}
+  - {fileID: 1880727418}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -7744,6 +8242,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   unitPrefab: {fileID: 7387470101939567078, guid: 2fd52b6a9bf887b47b8b0d6f08941b18, type: 3}
+  blockAreaLayer:
+    serializedVersion: 2
+    m_Bits: 0
 --- !u!114 &1691087147
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7822,6 +8323,10 @@ Transform:
   - {fileID: 1535556335}
   - {fileID: 379940063}
   - {fileID: 1553490278}
+  - {fileID: 1241678192}
+  - {fileID: 656992627}
+  - {fileID: 1271740834}
+  - {fileID: 1822731989}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1750296851
@@ -8139,6 +8644,93 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1755107508}
   m_CullTransparentMesh: 1
+--- !u!1 &1822731988
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1822731989}
+  - component: {fileID: 1822731990}
+  m_Layer: 0
+  m_Name: BridgePoint_Up_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1822731989
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1822731988}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.52, y: 3.51, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1699896757}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1822731990
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1822731988}
+  m_Enabled: 0
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &1831260603
 GameObject:
   m_ObjectHideFlags: 0
@@ -8462,6 +9054,139 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1866719075}
+  m_CullTransparentMesh: 1
+--- !u!1 &1880727417
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1880727418}
+  - component: {fileID: 1880727421}
+  - component: {fileID: 1880727420}
+  - component: {fileID: 1880727419}
+  m_Layer: 5
+  m_Name: HideUIButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1880727418
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1880727417}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.1770104, y: 1.1770104, z: 1.1770104}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 975575537}
+  m_Father: {fileID: 1615268164}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -912.8037, y: -468}
+  m_SizeDelta: {x: 202.6531, y: 135.93}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1880727419
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1880727417}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1880727420}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1852798265}
+        m_TargetAssemblyTypeName: UnitUIManager, Assembly-CSharp
+        m_MethodName: HideSquadUI
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1880727420
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1880727417}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1880727421
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1880727417}
   m_CullTransparentMesh: 1
 --- !u!1 &1898253970
 GameObject:
@@ -8787,6 +9512,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   unitPrefab: {fileID: 7387470101939567078, guid: 2fd52b6a9bf887b47b8b0d6f08941b18, type: 3}
+  blockAreaLayer:
+    serializedVersion: 2
+    m_Bits: 0
 --- !u!114 &1924117726
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8825,93 +9553,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1924117723}
   m_CullTransparentMesh: 1
---- !u!1 &1926614198
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1926614200}
-  - component: {fileID: 1926614199}
-  m_Layer: 0
-  m_Name: UnitSpawnPoint
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!212 &1926614199
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1926614198}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
-  m_Color: {r: 0.6933962, g: 1, b: 0.9851505, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &1926614200
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1926614198}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 7.39, y: -1.57, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1929945234
 GameObject:
   m_ObjectHideFlags: 0
@@ -9313,8 +9954,8 @@ MonoBehaviour:
   - {fileID: 1483928338}
   - {fileID: 1018204960}
   unitObj: {fileID: 7387470101939567078, guid: 2fd52b6a9bf887b47b8b0d6f08941b18, type: 3}
-  UnitSpawnPoint: {fileID: 1926614200}
-  EnemySpawnPoint: {fileID: 326033493}
+  UnitSpawnPoint: {fileID: 0}
+  EnemySpawnPoint: {fileID: 0}
 --- !u!4 &2020192914
 Transform:
   m_ObjectHideFlags: 0
@@ -10052,7 +10693,5 @@ SceneRoots:
   - {fileID: 2020192914}
   - {fileID: 1852798266}
   - {fileID: 1750296853}
-  - {fileID: 1926614200}
-  - {fileID: 326033493}
   - {fileID: 103602660}
   - {fileID: 1699896757}

--- a/Infection/Assets/Scripts/Unit/StatePattern/CombatState.cs
+++ b/Infection/Assets/Scripts/Unit/StatePattern/CombatState.cs
@@ -1,11 +1,15 @@
 using StrategyPatteren.Role;
 using UnityEngine;
+using static UnityEngine.GraphicsBuffer;
 
 namespace StatePatteren.State
 {
     public class CombatState : UnitState
     {
         UnitController unitController;
+        GameObject target;
+        GameObject allyCastle;
+        GameObject enemyCastle;
 
         float atkSpd = 0;
 
@@ -18,6 +22,9 @@ namespace StatePatteren.State
 
         public void Enter()
         {
+            allyCastle = GameObject.Find("Ally_Castle").gameObject;
+            enemyCastle = GameObject.Find("Enemy_Castle").gameObject;
+
             atkSpd = unitController.unitStats.atkSpd;
             time = atkSpd;
         }
@@ -25,6 +32,19 @@ namespace StatePatteren.State
         public void Update()
         {
             ActionTimer();
+
+            GetTargetSystem getTargetSystem = new GetTargetSystem();
+
+            if (unitController.GetUnitGroup() == UnitController.UNIT_GROUP.PLAYER)
+            {
+                target = getTargetSystem.GetTarget(unitController.gameObject, "Enemy");
+                CastleTarget(enemyCastle.transform.position);
+            }
+            else if (unitController.GetUnitGroup() == UnitController.UNIT_GROUP.ENEMY)
+            {
+                target = getTargetSystem.GetTarget(unitController.gameObject, "Player");
+                CastleTarget(allyCastle.transform.position);
+            }
         }
 
         public void Exit()
@@ -34,24 +54,7 @@ namespace StatePatteren.State
 
         public void Transition()
         {
-            GetTargetSystem getTargetSystem = new GetTargetSystem();
-
-            if (unitController.GetUnitGroup() == UnitController.UNIT_GROUP.PLAYER)
-            {
-                GameObject target = getTargetSystem.GetTarget(unitController.gameObject, "Enemy");
-                if (target == null)
-                {
-                    unitController.StateMachine.TransitionTo(unitController.StateMachine.moveState);
-                }
-            }
-            if (unitController.GetUnitGroup() == UnitController.UNIT_GROUP.ENEMY)
-            {
-                GameObject target = getTargetSystem.GetTarget(unitController.gameObject, "Player");
-                if (target == null)
-                {
-                    unitController.StateMachine.TransitionTo(unitController.StateMachine.moveState);
-                }
-            }
+            unitController.StateMachine.TransitionTo(unitController.StateMachine.moveState);            
         }
 
         // s“®‘¬“x
@@ -70,6 +73,18 @@ namespace StatePatteren.State
         {
             IRoleBehavior behavior = RoleBehaviorFactory.Get(stats.role);
             behavior.Action(unitController);
+        }
+
+        void CastleTarget(Vector3 targetCastle)
+        {
+            if (target == null)
+            {
+                float dist = Vector3.Distance(unitController.transform.position, targetCastle);
+                if (dist > unitController.unitStats.range)
+                {
+                    Transition();
+                }
+            }
         }
     }
 }

--- a/Infection/Assets/Scripts/Unit/StatePattern/MoveState.cs
+++ b/Infection/Assets/Scripts/Unit/StatePattern/MoveState.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using static UnityEngine.GraphicsBuffer;
 
 namespace StatePatteren.State
 {
@@ -7,8 +8,12 @@ namespace StatePatteren.State
         UnitController unitController;
         MoveSystem moveSystem;
 
+        GameObject target;
+        GameObject allyCastle;
+        GameObject enemyCastle;
+
         float moveSpeed = 0f;
-        Vector3 moveVector = Vector3.zero;
+        Vector3 unitPos = Vector3.zero;
 
         public MoveState(UnitController unitController)
         {
@@ -17,6 +22,9 @@ namespace StatePatteren.State
 
         public void Enter()
         {
+            allyCastle = GameObject.Find("Ally_Castle").gameObject;
+            enemyCastle = GameObject.Find("Enemy_Castle").gameObject;
+
             moveSpeed = unitController.unitStats.spd;
             moveSystem = new MoveSystem();
         }
@@ -25,12 +33,22 @@ namespace StatePatteren.State
         {
             if(unitController.GetUnitGroup() == UnitController.UNIT_GROUP.PLAYER)
             {
-                moveSystem.Move(unitController.gameObject, "Enemy", moveSpeed, moveVector);
+                unitPos = moveSystem.Move(unitController.gameObject, "Enemy", moveSpeed);
+                TargetInRange(enemyCastle.transform.position);
             }
-            if (unitController.GetUnitGroup() == UnitController.UNIT_GROUP.ENEMY)
+            else if (unitController.GetUnitGroup() == UnitController.UNIT_GROUP.ENEMY)
             {
-                moveSystem.Move(unitController.gameObject, "Player", moveSpeed, moveVector);
+                unitPos = moveSystem.Move(unitController.gameObject, "Player", moveSpeed);
+                TargetInRange(allyCastle.transform.position);
             }
+
+            if (target != null)
+            {
+                TargetInRange(target.transform.position);
+            }
+
+            unitController.transform.position = unitPos;
+            SetTarget();
         }
 
         public void Exit()
@@ -40,31 +58,31 @@ namespace StatePatteren.State
 
         public void Transition()
         {
+            unitController.StateMachine.TransitionTo(unitController.StateMachine.combatState);
+        }
+
+        // çUåÇëŒè€ÇÃéÊìæ
+        void SetTarget()
+        {
             GetTargetSystem getTargetSystem = new GetTargetSystem();
 
             if (unitController.GetUnitGroup() == UnitController.UNIT_GROUP.PLAYER)
             {
-                GameObject target = getTargetSystem.GetTarget(unitController.gameObject, "Enemy");
-                if(target != null)
-                {
-                    float distance = Vector2.Distance(unitController.gameObject.transform.position, target.transform.position);
-                    if (distance <= unitController.unitStats.range)
-                    {
-                        unitController.StateMachine.TransitionTo(unitController.StateMachine.combatState);
-                    }
-                }
+                target = getTargetSystem.GetTarget(unitController.gameObject, "Enemy");
             }
-            else
+            else if (unitController.GetUnitGroup() == UnitController.UNIT_GROUP.ENEMY)
             {
-                GameObject target = getTargetSystem.GetTarget(unitController.gameObject, "Player");
-                if (target != null)
-                {
-                    float distance = Vector2.Distance(unitController.gameObject.transform.position, target.transform.position);
-                    if (distance <= unitController.unitStats.range)
-                    {
-                        unitController.StateMachine.TransitionTo(unitController.StateMachine.combatState);
-                    }
-                }
+                target = getTargetSystem.GetTarget(unitController.gameObject, "Player");
+            }
+        }
+
+        // ëŒè€Ç™çUåÇîÕàÕì‡ÇæÇ¡ÇΩÇÁèÛë‘ëJà⁄
+        void TargetInRange(Vector3 target)
+        {
+            float dist = Vector3.Distance(unitController.transform.position, target);
+            if (dist <= unitController.unitStats.range)
+            {
+                Transition();
             }
         }
     }

--- a/Infection/Assets/Scripts/Unit/StatePattern/ReadyState.cs
+++ b/Infection/Assets/Scripts/Unit/StatePattern/ReadyState.cs
@@ -17,26 +17,37 @@ namespace StatePatteren.State
 
         public void Enter()
         {
-
+            SetDragPreviewAlpha(unitController.gameObject, 0.5f);
         }
 
         public async void Update()
         {
             await WaitEndDrag.WaitDragEndAsync();
             time += Time.deltaTime;
+            if (time >= sortieTime)
+            {
+                Transition();
+            }
         }
 
         public void Exit()
         {
-            
+            SetDragPreviewAlpha(unitController.gameObject, 1.0f);
         }
 
         // TransitionTo‚ðŒÄ‚Ño‚·‚½‚ß‚Ìˆ—
         public void Transition()
         {
-            if(time >= sortieTime)
+            unitController.StateMachine.TransitionTo(unitController.StateMachine.moveState);            
+        }
+
+        private void SetDragPreviewAlpha(GameObject obj, float alpha)
+        {
+            foreach (var sr in obj.GetComponentsInChildren<SpriteRenderer>())
             {
-                unitController.StateMachine.TransitionTo(unitController.StateMachine.moveState);
+                Color c = sr.color;
+                c.a = alpha;
+                sr.color = c;
             }
         }
     }

--- a/Infection/Assets/Scripts/Unit/UnitController.cs
+++ b/Infection/Assets/Scripts/Unit/UnitController.cs
@@ -54,7 +54,6 @@ namespace StatePatteren.State
         void Update()
         {
             stateMachine.Update();
-            stateMachine.Transition();
         }
 
         // ƒ_ƒ[ƒWˆ—

--- a/Infection/Assets/Scripts/Unit/UnitSystem/MoveSystem.cs
+++ b/Infection/Assets/Scripts/Unit/UnitSystem/MoveSystem.cs
@@ -3,30 +3,117 @@ using UnityEngine;
 
 public class MoveSystem
 {
+    enum STEP
+    {
+        GO_BRIDGE,
+        GO_CASTLE,
+    }
+
+    STEP step;
+    bool toPoint = false;
+    Vector3 myPos;
+
+    float oldDist = 100.0f;
+    Vector3 nearPos = Vector3.zero;
+    Vector3 nextPos = Vector3.zero;
+
+    Vector3[] point = new Vector3[4];
+    Vector3 allyCastle = Vector3.zero;
+    Vector3 enemyCastle = Vector3.zero;
+
+    Vector3 targetDireciton = Vector3.zero;
+
+    public MoveSystem()
+    {
+        step = STEP.GO_BRIDGE;
+
+        point[0] = GameObject.Find("BridgePoint_Down_R").transform.position;
+        point[1] = GameObject.Find("BridgePoint_Down_L").transform.position;
+        point[2] = GameObject.Find("BridgePoint_Up_R").transform.position;
+        point[3] = GameObject.Find("BridgePoint_Up_L").transform.position;
+
+        allyCastle = GameObject.Find("Ally_Castle").transform.position;
+        enemyCastle = GameObject.Find("Enemy_Castle").transform.position;
+    }
+
     // 移動
-    public void Move(GameObject myObj, string targetTag, float moveSpeed, Vector3 vector)
+    public Vector3 Move(GameObject myObj, string targetTag, float moveSpeed)
     {
         GetTargetSystem getTarget = new GetTargetSystem();
         GameObject target = getTarget.GetTarget(myObj, targetTag);
-
+        myPos = myObj.transform.position;
+        
         if (target == null)
         {
-            if (targetTag == "Enemy")
+            switch (step)
             {
-                vector = new Vector3(-1, 0);
-            }
-            else
-            {
-                vector = new Vector3(1, 0);
+                case STEP.GO_BRIDGE:
+                    targetDireciton = ToBridge(myObj);
+                    break;
+                case STEP.GO_CASTLE:
+                    targetDireciton = ToCastle(myObj, targetTag);
+                    break;
             }
         }
         else
         {
-            vector = target.transform.position - myObj.transform.position;
+            targetDireciton = target.transform.position;
         }
 
         // 移動
-        Vector3 moveVelocity = vector.normalized * moveSpeed * 0.1f * Time.deltaTime;
-        myObj.transform.position += moveVelocity;
+        Vector3 moveVelocity = (targetDireciton - myPos).normalized * moveSpeed * 0.1f * Time.deltaTime;
+        return myPos += moveVelocity;
+    }
+
+    // 橋まで移動
+    Vector3 ToBridge(GameObject myObj)
+    {
+        // 上下の橋で近い方に向かう
+        if (nearPos == Vector3.zero && nextPos == Vector3.zero)
+        {
+            foreach(var p in point)
+            {
+                var dist = Vector3.Distance(myPos, p);
+                if (dist < oldDist)
+                {
+                    oldDist = dist;
+                    nearPos = p;
+
+                    foreach(var np in point)
+                    {
+                        if (nearPos.y == np.y && nearPos != np)
+                        {
+                            nextPos = np;
+                        }
+                    }
+                }
+            }
+        }
+                
+        var pointDist = Vector3.Distance(myPos, nearPos);
+        if(pointDist <= 0.1f || toPoint)
+        {
+            toPoint = true;
+
+            var nextDist = Vector3.Distance(myPos, nextPos);
+
+            // 橋を渡り切ったら城へ向かうステップに移行
+            if (nextDist <= 0.1f)
+            {
+                step = STEP.GO_CASTLE;
+            }
+
+            return nextPos;
+        }
+        else
+        {
+            return nearPos;
+        }
+    }
+
+    // 城まで移動
+    Vector3 ToCastle(GameObject myObj, string targetTag)
+    {
+        return targetTag == "Enemy" ? enemyCastle : allyCastle;
     }
 }

--- a/Infection/Assets/Scripts/Unit/UnitUIManager.cs
+++ b/Infection/Assets/Scripts/Unit/UnitUIManager.cs
@@ -25,17 +25,10 @@ public class UnitUIManager : MonoBehaviour
         UnitParaTexts();
     }
 
-    // Update is called once per frame
-    void Update()
+    public void HideSquadUI()
     {
-        if (Input.GetKey(KeyCode.LeftShift))
-        {
-            if(Input.GetKeyDown(KeyCode.LeftAlt))
-            {
-                SquadUI.gameObject.SetActive(!isActive);
-                isActive = !isActive;
-            }
-        }
+        SquadUI.gameObject.SetActive(!isActive);
+        isActive = !isActive;
     }
 
     // 部隊のステータス表示


### PR DESCRIPTION
■MoveSystem改良
・ユニットの移動の際に橋を渡って相手の城へ向かうようになった

■MoveState改良
・重複していた処理を関数化し、改善
・射程距離内に相手の城がある場合に、戦闘状態に遷移するようになった。